### PR TITLE
change api call to get all the photo's information with one call

### DIFF
--- a/app/services/facebook_service.rb
+++ b/app/services/facebook_service.rb
@@ -5,21 +5,13 @@ class FacebookService
   end
 
   def self.uploaded_photos_call(user)
-    self.get_data_call("https://graph.facebook.com/v2.10/#{user.fb_id}/photos?type=uploaded&access_token=#{user.token}", user)
+    response = Faraday.get("https://graph.facebook.com/v2.10/#{user.fb_id}/photos?type=uploaded&fields=created_time,from,id,images,name,link,place,comments{like_count,comment_count,message,likes,from},tags{id,name},reactions{id,name,username,type}&access_token=#{user.token}")
+    response_json = JSON.parse(response.body, symbolize_names: true)[:data]
     # uploaded_photos_call(response_json[:paging][:next]) if response_json[:paging][:next]
   end
 
   # def tagged_photos_call
   #   get_data_call("https://graph.facebook.com/v2.10/#{ENV['my_fb_id']}/photos&access_token=#{ENV['my_fb_token']}")
-  #   # uploaded_photos_call(response_json[:paging][:next]) if response_json[:paging][:next]
+  #   uploaded_photos_call(response_json[:paging][:next]) if response_json[:paging][:next]
   # end
-
-  def self.get_data_call(url, user)
-    response = Faraday.get(url)
-    response_json = JSON.parse(response.body, symbolize_names: true)
-    response_json[:data].map do |photo|
-      data_response = Faraday.get("https://graph.facebook.com/v2.10/#{photo[:id]}?fields=backdated_time,backdated_time_granularity,created_time,from,id,images,name,link,place,comments{like_count,comment_count,message,likes,from},tags{id,name},reactions{id,name,username,type}&access_token=#{user.token}")
-      JSON.parse(data_response.body, symbolize_names: true)
-    end
-  end
 end


### PR DESCRIPTION
#### What does  this PR do?
change the fb_api call to only one request instead of 26

#### Where should the reviewer start?
the only change is in app/services/facebook_service.rb 

#### How should this be manually tested?
`rspec spec/services/facebook_service_spec.rb`

#### Any background context you want to provide?
We used to make 26 calls, one to get a list of 25 picture_ids and 25 calls to get the information of each picture. The facebook documentation only shows the call per photo_id but playing with the fields we managed to get all of them with just one call.

No new migrations or ENV variables